### PR TITLE
Set explicit version of numba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 mlcrate==0.1.0
 numpy==1.21.2
+numba==0.57.1
 scipy==1.10.1
 opencv-python==4.6.0.66
 pandas>=0.23.1


### PR DESCRIPTION
The version of numba that is installed during setup is not compatible with numpy-1.21.2. Set numba version to the same we use in production